### PR TITLE
Fixes an issue opening a workspace from a Podfile

### DIFF
--- a/lib/pod/command/try.rb
+++ b/lib/pod/command/try.rb
@@ -123,11 +123,13 @@ module Pod
       def install_podfile(proj)
         return unless proj
         dirname = Pathname.new(proj).dirname
-        podfile = dirname + 'Podfile'
-        if podfile.exist?
+        podfile_path = dirname + 'Podfile'
+        if podfile_path.exist?
           Dir.chdir(dirname) do
             perform_cocoapods_installation
-            proj.chomp(File.extname(proj.to_s)) + '.xcworkspace'
+
+            podfile = Pod::Podfile.from_file(podfile_path)
+            File.expand_path(podfile.workspace_path)
           end
         else
           proj

--- a/spec/command/try_spec.rb
+++ b/spec/command/try_spec.rb
@@ -102,10 +102,11 @@ module Pod
           path.should == proj
         end
 
-        it "performs an installation and returns the path of the Podfile" do
+        it "performs an installation and returns the path of the workspace" do
           Pathname.any_instance.stubs(:exist?).returns(true)
           proj = "/tmp/Project.xcodeproj"
           @sut.expects(:perform_cocoapods_installation)
+          Podfile.stubs(:from_file).returns(stub(:workspace_path => "/tmp/Project.xcworkspace"))
           path = @sut.install_podfile(proj)
           path.should == "/tmp/Project.xcworkspace"
         end


### PR DESCRIPTION
The podfile might specify to use another workspace, and in this case we was just appending 'ProjectName.xcworkspace' to the path instead of using this. This resulted in a file not found when using pod try.
