### PR TITLE
Don’t consider actual files inside document bundles.

### DIFF
--- a/lib/pod/command/try.rb
+++ b/lib/pod/command/try.rb
@@ -94,7 +94,9 @@ module Pod
       #
       def pick_demo_project(dir)
         glob_match = Dir.glob("#{dir}/**/*.xc{odeproj,workspace}")
-        glob_match = glob_match.reject { |p| p.include?('Pods.xcodeproj') }
+        glob_match = glob_match.reject do |p|
+          p.include?('Pods.xcodeproj') || p.end_with?('.xcodeproj/project.xcworkspace')
+        end
 
         if glob_match.count == 0
           raise Informative, "Unable to find any project in the source files" \

--- a/spec/command/try_spec.rb
+++ b/spec/command/try_spec.rb
@@ -98,6 +98,12 @@ module Pod
           path = @sut.pick_demo_project(stub(:cleanpath => ''))
           path.should == 'Project Demo.xcworkspace'
         end
+
+        it "should not show workspaces inside a project" do
+          Dir.stubs(:glob).returns(['Project Demo.xcodeproj', 'Project Demo.xcodeproj/project.xcworkspace'])
+          path = @sut.pick_demo_project(stub(:cleanpath => ''))
+          path.should == 'Project Demo.xcodeproj'
+        end
       end
 
       describe "#install_podfile" do


### PR DESCRIPTION
In this example option 2 should have been omitted.

```
~/C/C/trunk.cocoapods.org [master] » pod try LMAlertView
Updating spec repositories

Trying LMAlertView
1: LMAlertViewDemo.xcodeproj
2: LMAlertViewDemo.xcodeproj/project.xcworkspace
3: LMAlertViewDemo.xcworkspace
Which project would you like to open [1-3]?
```
