### PR TITLE
Allow to pass URL instead of the name of the Pod

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gemspec
+gemspec :name => "cocoapods-try-release-fix"
 
 group :development do
   gem 'cocoapods'


### PR DESCRIPTION
A somewhat naive implementation of adding URL handling so you can pass
in an http/https/github-ssh based URL to pod try.

I didn’t want to stomp on the cocoapods-try-release-fix.gemspec because
it was just added back to the repo, but I did specify an explicit name
in the Gemfile.
