### PR TITLE
Explicitly specify gem name in Rakefile and Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gemspec
+gemspec :name => "cocoapods-try-release-fix"
 
 group :development do
   gem 'cocoapods'

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,5 @@
-require "bundler/gem_tasks"
+require 'bundler/gem_helper'
+Bundler::GemHelper.install_tasks(:name => "cocoapods-try-release-fix")
 
 def specs(dir)
   FileList["spec/#{dir}/*_spec.rb"].shuffle.join(' ')


### PR DESCRIPTION
Fixes previous error message when running `rake bootstrap` of “Unable
to determine name from existing gemspec.”
