### PR TITLE
Do not update spec repo when passing in a URL

### DIFF
--- a/lib/pod/command/try.rb
+++ b/lib/pod/command/try.rb
@@ -23,7 +23,7 @@ module Pod
       end
 
       def is_git_url(name)
-        ['https://', 'http://', 'git@github'].each do |prefix|
+        ['https://', 'http://'].each do |prefix|
           return true if name.start_with? prefix
         end
         false
@@ -34,8 +34,8 @@ module Pod
           spec = spec_with_url(@name)
         else
           spec = spec_with_name(@name)
+          update_specs_repos
         end
-        update_specs_repos
         UI.title "Trying #{spec.name}" do
           pod_dir = install_pod(spec, TRY_TMP_DIR)
           proj = pick_demo_project(pod_dir)

--- a/spec/command/try_spec.rb
+++ b/spec/command/try_spec.rb
@@ -31,7 +31,7 @@ module Pod
         Config.instance.skip_repo_update = false
         command = Pod::Command.parse(['try', 'https://github.com/orta/ARAnalytics.git'])
         Installer::PodSourceInstaller.any_instance.expects(:install!)
-        command.expects(:update_specs_repos)
+        command.expects(:update_specs_repos).never
         command.expects(:pick_demo_project).returns("/tmp/Proj.xcodeproj")
         command.expects(:open_project).with('/tmp/Proj.xcodeproj')
         command.run
@@ -61,11 +61,6 @@ module Pod
 
         it "returns a spec for a github url" do
           spec = @sut.spec_with_url('https://github.com/orta/ARAnalytics')
-          spec.name.should == "ARAnalytics"
-        end
-
-        it "returns a spec for a git ssh url" do
-          spec = @sut.spec_with_url('git@github.com:orta/ARAnalytics.git')
           spec.name.should == "ARAnalytics"
         end
 


### PR DESCRIPTION
Only call `update_specs_repos` when using a named Pod.

Also, temporarily removed support for `git@github` style URLs until I
can test that without requiring the github.com ssh key added to the
travis environment - as seen in
https://travis-ci.org/CocoaPods/cocoapods-try/jobs/20141514

Any feedback on how best to test this? Should I be using VCR so it
doesn’t actually call out to the server?
