### PR TITLE
Added a command line option for specifying the podspec file from Git URL

### DIFF
--- a/spec/command/try_spec.rb
+++ b/spec/command/try_spec.rb
@@ -19,6 +19,13 @@ module Pod
         end.message.should.match(/A Pod name or URL is required/)
       end
 
+      it 'presents the help if name and location is provided' do
+        command = Pod::Command.parse(%w(try ARAnalytics --podspec_location=Analytics.podspec))
+        should.raise CLAide::Help do
+          command.validate!
+        end.message.should.match(/Location to podspec can only be used with a Git URL/)
+      end
+
       before do
         @original_install_method = method = Pod::Command::Try.instance_method(:install_pod)
         Pod::Command::Try.send(:define_method, :install_pod) do |*args|
@@ -97,6 +104,17 @@ module Pod
           stub_spec = stub
           Pod::Specification.stubs(:from_file).with(spec_file).returns(stub_spec)
           spec = @sut.spec_with_url('https://github.com/orta/ARAnalytics.git')
+          spec.should == stub_spec
+        end
+
+        it 'returns a spec for an https git repo with podspec_location option' do
+          require 'cocoapods-downloader/git'
+          Pod::Downloader::Git.any_instance.expects(:download)
+          spec_file = Pod::Command::Try::TRY_TMP_DIR + 'ARAnalytics/Analytics.podspec'
+          Pathname.stubs(:glob).once.returns([spec_file])
+          stub_spec = stub
+          Pod::Specification.stubs(:from_file).with(spec_file).returns(stub_spec)
+          spec = @sut.spec_with_url('https://github.com/orta/ARAnalytics.git', 'Analytics.podspec')
           spec.should == stub_spec
         end
       end


### PR DESCRIPTION
Added a option for specifying the name of the podspec file so that it does not need to be the same as the Git Repository.

Closes #54 