### PR TITLE
fixed missing `podfile` param in `PodSourceInstaller` init method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@
 
 ##### Bug Fixes
 
-* None.  
+* Fix a crash when using `pod try` with CocoaPods 1.8.0 or higher.  
+  [@arielpollack](https://github.com/arielpollack)
+  [#63](https://github.com/CocoaPods/cocoapods-try/issues/63)
+  [#65](https://github.com/CocoaPods/cocoapods-try/pull/65)
 
 
 ## 1.1.0 (2016-07-10)

--- a/lib/pod/command/try.rb
+++ b/lib/pod/command/try.rb
@@ -135,7 +135,8 @@ module Pod
       #
       def install_pod(spec, sandbox)
         specs = { :ios => spec, :osx => spec }
-        installer = Installer::PodSourceInstaller.new(sandbox, specs, :can_cache => false)
+        dummy_podfile = Podfile.new
+        installer = Installer::PodSourceInstaller.new(sandbox, dummy_podfile, specs, :can_cache => false)
         installer.install!
         sandbox.root + spec.name
       end

--- a/lib/pod/command/try.rb
+++ b/lib/pod/command/try.rb
@@ -135,8 +135,12 @@ module Pod
       #
       def install_pod(spec, sandbox)
         specs = { :ios => spec, :osx => spec }
-        dummy_podfile = Podfile.new
-        installer = Installer::PodSourceInstaller.new(sandbox, dummy_podfile, specs, :can_cache => false)
+        if cocoapods_version >= Pod::Version.new('1.8.0')
+          dummy_podfile = Podfile.new
+          installer = Installer::PodSourceInstaller.new(sandbox, dummy_podfile, specs, :can_cache => false)
+        else
+          installer = Installer::PodSourceInstaller.new(sandbox, specs, :can_cache => false)
+        end
         installer.install!
         sandbox.root + spec.name
       end
@@ -261,6 +265,12 @@ module Pod
           sister_workspace = p.chomp(File.extname(p.to_s)) + '.xcworkspace'
           p.end_with?('.xcodeproj') && glob_match.include?(sister_workspace)
         end
+      end
+
+      # @return [Pod::Version] the version of CocoaPods currently running
+      #
+      def cocoapods_version
+        Pod::Version.new(Pod::VERSION)
       end
 
       #-------------------------------------------------------------------#

--- a/spec/command/try_spec.rb
+++ b/spec/command/try_spec.rb
@@ -128,6 +128,25 @@ module Pod
         path.should == sandbox.root + 'ARAnalytics'
       end
 
+      it 'installs the pod on older versions of CocoaPods' do
+        @sut.stubs(:cocoapods_version).returns(Pod::Version.new('1.7.0'))
+        spec = stub(:name => 'ARAnalytics')
+        sandbox_root = Pathname.new(Pod::Command::Try::TRY_TMP_DIR)
+        sandbox = Sandbox.new(sandbox_root)
+        installer = stub('Installer')
+        installer.stubs(:install!)
+        Pod::Installer::PodSourceInstaller.expects(:new).with(any_parameters) do |*args|
+          args.size == 3
+        end.returns(installer).once
+        @sut.install_pod(spec, sandbox)
+
+        @sut.stubs(:cocoapods_version).returns(Pod::Version.new('1.8.0'))
+        Pod::Installer::PodSourceInstaller.expects(:new).with(any_parameters) do |*args|
+          args.size == 4
+        end.returns(installer)
+        @sut.install_pod(spec, sandbox)
+      end
+
       describe '#pick_demo_project' do
         it 'raises if no demo project could be found' do
           @sut.stubs(:projects_in_dir).returns([])


### PR DESCRIPTION
Fixes #63 .
The origin of the issue is this commit: https://github.com/CocoaPods/CocoaPods/commit/3e1bcb76578fb22d8d7010356d93d637c586205f#diff-c4753c6ef7b884f38303f1554a19cd69R39